### PR TITLE
Use numeric version when sending request

### DIFF
--- a/incremental-reading.el
+++ b/incremental-reading.el
@@ -187,7 +187,7 @@ is successful, update the ANKI-BLOCK id."
     :type "POST"
     :sync t
     :data (json-encode `(("action" . "addNote")
-                         ("version" . "6")
+                         ("version" . 6)
                          ("params" . (("note" . (("deckName" . ,deck)
                                                  ("modelName" . ,card-type)
                                                  ("fields" . ,fields)
@@ -210,7 +210,7 @@ FIELDS and TAGS of the card."
     :type "POST"
     :sync t
     :data (json-encode `(("action" . "updateNoteFields")
-                         ("version" . "6")
+                         ("version" . 6)
                          ("params" . (("note" . (("id" . ,(string-to-number id))
                                                  ("fields" . ,fields)
                                                  ("tags" . (,tags))))))))


### PR DESCRIPTION
The latest version of anki connect expects version to be integer and fails when passed as string.
This is the error I get when trying to parse the response:
```
(request-response 200 nil ((result) (error . "'6' is not of type 'integer'

Failed validating 'type' in schema['properties']['version']:
    {'type': 'integer'}
```

The attached change fixes the error